### PR TITLE
Handle small sample fallback in forecast

### DIFF
--- a/tests/test_ts_core.py
+++ b/tests/test_ts_core.py
@@ -1,6 +1,8 @@
+import os, sys, io
 import pandas as pd, numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from ts_core import forecast_linear_safe, load_table, DataError
-import io
 
 def _make_df(n=20, start="2023-01-01"):
     dates = pd.date_range(start=start, periods=n, freq="D")

--- a/ts_core.py
+++ b/ts_core.py
@@ -51,8 +51,6 @@ def _prepare(df: pd.DataFrame, date_col: str, target_col: str) -> pd.DataFrame:
     s[target_col] = pd.to_numeric(s[target_col], errors="coerce")
     s = s[[date_col, target_col]].dropna().sort_values(date_col)
     s = s[~s[date_col].duplicated(keep="last")]
-    if len(s) < 3:
-        raise DataError("Not enough clean rows (need ≥3).")
     return s
 
 def _infer_offset(dates: pd.Series):
@@ -89,7 +87,7 @@ def forecast_linear_safe(df: pd.DataFrame, date_col: str, target_col: str, horiz
         })
 
     try:
-        if horizon < 1 or horizon > 10000 or not np.isfinite(y).all():
+        if n < 3 or horizon < 1 or horizon > 10000 or not np.isfinite(y).all():
             raise DataError("Invalid horizon or values.")
         model = LinearRegression().fit(X, y)
         fut = np.arange(n, n + horizon).reshape(-1, 1)


### PR DESCRIPTION
## Summary
- Handle short datasets by falling back to naive forecast instead of raising DataError.
- Ensure tests can import repository modules by appending project root to sys.path.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b955a6efc83338de83f49ea1e9ec2