### PR TITLE
Handle sub-day frequency offset inference

### DIFF
--- a/tests/test_ts_core.py
+++ b/tests/test_ts_core.py
@@ -28,3 +28,12 @@ def test_load_table_csv():
     df = load_table(f)
     assert not df.empty
 
+def test_subday_frequency_offset():
+    df = pd.DataFrame({
+        "date": pd.date_range("2023-01-01", periods=2, freq="h"),
+        "value": [1, 2],
+    })
+    out = forecast_linear_safe(df, "date", "value", horizon=2)
+    diffs = out["date"].diff().dropna()
+    assert (diffs == pd.Timedelta(hours=1)).all()
+

--- a/ts_core.py
+++ b/ts_core.py
@@ -61,9 +61,14 @@ def _infer_offset(dates: pd.Series):
     except Exception:
         pass
     diffs = dates.diff().dropna()
-    if len(diffs) and hasattr(diffs.iloc[0], "days"):
-        days = int(max(1, diffs.median().days))
-        return pd.DateOffset(days=days)
+    if len(diffs):
+        med = diffs.median()
+        try:
+            return pd.tseries.frequencies.to_offset(med)
+        except Exception:
+            if hasattr(med, "days"):
+                days = int(max(1, med.days))
+                return pd.DateOffset(days=days)
     return pd.DateOffset(days=1)
 
 def forecast_linear_safe(df: pd.DataFrame, date_col: str, target_col: str, horizon: int) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- allow `_infer_offset` to compute sub-day offsets from median differences
- add regression test ensuring hourly forecasts maintain 1-hour spacing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c461ff0148333b5c60e512439a70d