### PR TITLE
Auto-run forecasts on data changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Simple Time-Series Predictor (Streamlit)
 Minimal Streamlit app to upload CSV/XLS/XLSX or delimited text and generate a small baseline forecast safely. The helper utilities can also auto-detect feature types (dates, numbers, categories, booleans) and train simple regression models such as RandomForest or LightGBM.
 
+On startup a random sample from `test_files` is loaded and forecasts refresh automatically whenever the data or settings change—no prediction button needed.
+
 ## Run locally
 ```bash
 python -m venv .venv && source .venv/bin/activate   # Windows: .venv\\Scripts\\activate

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,4 @@
 import streamlit as st
-import pandas as pd
 import random
 from pathlib import Path
 from ts_core import load_table, infer_date_and_target, forecast_linear_safe, DataError, detect_interval
@@ -41,19 +40,18 @@ target_col = st.selectbox("Target (numeric)", candidates,
 
 st.caption(f"Detected interval: {detect_interval(df[date_col])}")
 
-if st.button("Run baseline forecast"):
-    try:
-        out = forecast_linear_safe(df, date_col, target_col, int(horizon))
-        st.subheader("Forecast")
-        st.line_chart(out.set_index("date")[["y", "yhat"]])
-        st.download_button("Download predictions as CSV",
-                           out.to_csv(index=False).encode("utf-8"),
-                           file_name="predictions.csv", mime="text/csv")
-        with st.expander("Details"):
-            st.dataframe(out.tail(min(50, len(out))))
-    except DataError as e:
-        st.error(str(e))
-    except Exception as e:
-        st.error(f"Unexpected error: {e}")
+try:
+    out = forecast_linear_safe(df, date_col, target_col, int(horizon))
+    st.subheader("Forecast")
+    st.line_chart(out.set_index("date")[["y", "yhat"]])
+    st.download_button("Download predictions as CSV",
+                       out.to_csv(index=False).encode("utf-8"),
+                       file_name="predictions.csv", mime="text/csv")
+    with st.expander("Details"):
+        st.dataframe(out.tail(min(50, len(out))))
+except DataError as e:
+    st.error(str(e))
+except Exception as e:
+    st.error(f"Unexpected error: {e}")
 
 st.caption("Baseline uses scikit-learn LinearRegression with a safe fallback to last value if modeling fails.")


### PR DESCRIPTION
## Summary
- Remove manual forecast trigger and compute predictions automatically whenever data or settings change
- Load a random sample file on startup and note behaviour in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c5c416aec8333a4893962a9246ee2