### PR TITLE
Add placeholder test and update agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,5 @@ This repository is maintained without human review. Follow these rules:
 - Do not add GitHub Actions or external CI without instruction.
 - Use 4-space indentation and simple, readable Python.
 - After committing, open a PR with `make_pr` and fast-forward merge into `main`.
+- Update this file whenever repository procedures or rules change.
 

--- a/tests/test_automerge_dummy.py
+++ b/tests/test_automerge_dummy.py
@@ -1,0 +1,10 @@
+import os, sys
+import pandas as pd
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from ts_core import detect_interval
+
+
+def test_detect_interval_daily_series():
+    dates = pd.date_range('2024-01-01', periods=5, freq='D')
+    assert detect_interval(dates) == 'D (days)'


### PR DESCRIPTION
## Summary
- add simple test exercising `detect_interval`
- remind contributors to update AGENTS instructions when rules change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c99b40f748333b3a89683bf195440