### PR TITLE
Wrap preview data in Streamlit expander

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -28,7 +28,8 @@ else:
     except DataError as e:
         st.error(str(e)); st.stop()
 
-st.subheader("Preview"); st.dataframe(df.head(20))
+with st.expander("Preview"):
+    st.dataframe(df.head(20))
 auto_date, auto_target = infer_date_and_target(df)
 
 st.subheader("Select columns")


### PR DESCRIPTION
## Summary
- Hide initial dataframe preview behind a collapsible expander so users can open it on demand

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd50e32988333a91a3412f6a5c883