### PR TITLE
Display deployment info in Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,7 +1,23 @@
 import streamlit as st
 import random
 from pathlib import Path
+import subprocess
 from ts_core import load_table, infer_date_and_target, forecast_linear_safe, DataError, detect_interval
+
+
+def get_deploy_info():
+    """Return short git commit hash and commit datetime."""
+    try:
+        version = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"]
+        ).decode().strip()
+        deploy_time = subprocess.check_output(
+            ["git", "show", "-s", "--format=%ci", "HEAD"]
+        ).decode().strip()
+    except Exception:
+        version = "unknown"
+        deploy_time = "unknown"
+    return version, deploy_time
 
 st.set_page_config(page_title="Simple Time-Series Predictor", page_icon="⏱️", layout="wide")
 st.title("⏱️ Simple Time-Series Predictor (Baseline)")
@@ -55,3 +71,11 @@ except Exception as e:
     st.error(f"Unexpected error: {e}")
 
 st.caption("Baseline uses scikit-learn LinearRegression with a safe fallback to last value if modeling fails.")
+
+
+version, deploy_time = get_deploy_info()
+st.markdown(
+    f"<div style='position: fixed; bottom: 0; right: 0; font-size:0.75rem; color: gray;'>"
+    f"Version: {version}<br/>Last deploy: {deploy_time}</div>",
+    unsafe_allow_html=True,
+)


### PR DESCRIPTION
## Summary
- show git version and last deploy timestamp in the app footer

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cd5a080e083339da9ef2bc60e9f13