### PR TITLE
Rearrange and rename UI buttons

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -46,6 +46,13 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
 with st.sidebar:
     st.subheader("Data Input")
     
+    # File uploader
+    uploaded = st.file_uploader(
+        "Upload your data file",
+        type=["csv", "xlsx", "xls"],
+        help="CSV or Excel files up to 10 MB"
+    )
+    
     # Example files download
     example_files = sorted(DATA_DIR.glob("*"))
     if example_files:
@@ -55,18 +62,11 @@ with st.sidebar:
                 zf.write(example, arcname=example.name)
         buffer.seek(0)
         st.download_button(
-            "Download Examples",
+            "Examples",
             buffer.getvalue(),
             "examples.zip",
             help="Sample datasets for testing"
         )
-    
-    # File uploader
-    uploaded = st.file_uploader(
-        "Upload your data file",
-        type=["csv", "xlsx", "xls"],
-        help="CSV or Excel files up to 10 MB"
-    )
     
     # Forecast horizon
     horizon = st.number_input(


### PR DESCRIPTION
Move the "Examples" button after the file uploader and rename it to "Examples" for improved UI layout.

The "Browse files" button text could not be changed to "Open files" as requested, due to limitations of Streamlit's `st.file_uploader` component which does not allow direct customization of its default button text.

---
<a href="https://cursor.com/background-agent?bcId=bc-876dccac-cc36-40dd-ae92-54d37cbe7a13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-876dccac-cc36-40dd-ae92-54d37cbe7a13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

