### PR TITLE
Separate prophet model training into file

### DIFF
--- a/models/prophet_model.py
+++ b/models/prophet_model.py
@@ -1,0 +1,117 @@
+from typing import Tuple, Dict
+import itertools
+import logging
+
+import numpy as np
+import pandas as pd
+from prophet import Prophet
+
+
+def optimize_parameters(series_df: pd.DataFrame, test_fraction: float = 0.2) -> Dict:
+    """
+    Find optimal Prophet parameters for a dataset using grid search.
+
+    Args:
+        series_df: DataFrame with 'ds' and 'y' columns
+        test_fraction: Fraction of data to use for testing
+
+    Returns:
+        dict: Best parameters found
+    """
+    param_grid = {
+        'changepoint_prior_scale': [0.01, 0.05, 0.1, 0.5],
+        'seasonality_prior_scale': [1.0, 10.0, 20.0],
+        'daily_seasonality': [True, False],
+        'weekly_seasonality': [True, False],
+        'yearly_seasonality': [True, False],
+    }
+
+    keys = param_grid.keys()
+    values = param_grid.values()
+    param_combinations = [dict(zip(keys, combination)) for combination in itertools.product(*values)]
+
+    test_size = int(len(series_df) * test_fraction)
+    train_df = series_df.iloc[:-test_size].copy()
+    test_df = series_df.iloc[-test_size:].copy()
+
+    best_nrmse = float('inf')
+    best_params: Dict = {}
+
+    logging.getLogger('prophet').setLevel(logging.ERROR)
+
+    max_combinations = 20
+    param_combinations = param_combinations[:max_combinations]
+
+    for params in param_combinations:
+        try:
+            model = Prophet(**params)
+            model.fit(train_df)
+
+            future = model.make_future_dataframe(periods=test_size)
+            forecast = model.predict(future)
+
+            yhat_test = forecast['yhat'].iloc[-test_size:].to_numpy()
+            y_true = test_df['y'].to_numpy()
+            rmse = float(np.sqrt(np.mean((y_true - yhat_test) ** 2)))
+            y_range = np.max(y_true) - np.min(y_true)
+            nrmse = rmse / y_range if y_range > 0 else rmse
+
+            if nrmse < best_nrmse:
+                best_nrmse = nrmse
+                best_params = params.copy()
+        except Exception:
+            continue
+
+    if not best_params:
+        best_params = {
+            'daily_seasonality': True,
+            'weekly_seasonality': True,
+            'yearly_seasonality': True,
+            'changepoint_prior_scale': 0.05,
+            'seasonality_prior_scale': 10.0
+        }
+
+    return best_params
+
+
+def forecast_and_nrmse(series_df: pd.DataFrame, test_fraction: float = 0.2, optimize_params_flag: bool = True) -> Tuple[float, pd.DataFrame, pd.DataFrame]:
+    """
+    Compute Prophet forecast and NRMSE on test set.
+
+    Args:
+        series_df: DataFrame with 'ds' and 'y' columns
+        test_fraction: Fraction of data to use for testing
+        optimize_params_flag: Whether to optimize parameters for this dataset
+
+    Returns:
+        tuple: (nrmse, forecast_df, test_df)
+    """
+    test_size = int(len(series_df) * test_fraction)
+    train_df = series_df.iloc[:-test_size].copy()
+    test_df = series_df.iloc[-test_size:].copy()
+
+    if optimize_params_flag:
+        prophet_params = optimize_parameters(series_df, test_fraction)
+    else:
+        prophet_params = {
+            'daily_seasonality': True,
+            'weekly_seasonality': True,
+            'yearly_seasonality': True,
+            'changepoint_prior_scale': 0.05,
+            'seasonality_prior_scale': 10.0
+        }
+
+    model = Prophet(**prophet_params)
+    logging.getLogger('prophet').setLevel(logging.WARNING)
+    model.fit(train_df)
+
+    future = model.make_future_dataframe(periods=test_size)
+    forecast = model.predict(future)
+
+    yhat_test = forecast['yhat'].iloc[-test_size:].to_numpy()
+    y_true = test_df['y'].to_numpy()
+    rmse = float(np.sqrt(np.mean((y_true - yhat_test) ** 2)))
+    y_range = np.max(y_true) - np.min(y_true)
+    nrmse = rmse / y_range if y_range > 0 else rmse
+
+    return nrmse, forecast, test_df

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,10 +1,9 @@
 from typing import List, Tuple, Dict
-import itertools
 
 import numpy as np
 import pandas as pd
 import streamlit as st
-from prophet import Prophet
+from models.prophet_model import forecast_and_nrmse as prophet_forecast_and_nrmse
 
 
 st.set_page_config(page_title="TS Forecasting Benchmark", layout="wide")
@@ -159,141 +158,6 @@ def _prepare_single_series(df: pd.DataFrame) -> pd.DataFrame:
     return sub
 
 
-def _optimize_prophet_parameters(series_df: pd.DataFrame, test_fraction: float = 0.2) -> Dict:
-    """
-    Find optimal Prophet parameters for a dataset using grid search.
-    
-    Args:
-        series_df: DataFrame with 'ds' and 'y' columns
-        test_fraction: Fraction of data to use for testing
-        
-    Returns:
-        dict: Best parameters found
-    """
-    # Define parameter grid for optimization
-    param_grid = {
-        'changepoint_prior_scale': [0.01, 0.05, 0.1, 0.5],
-        'seasonality_prior_scale': [1.0, 10.0, 20.0],
-        'daily_seasonality': [True, False],
-        'weekly_seasonality': [True, False],
-        'yearly_seasonality': [True, False],
-    }
-    
-    # Generate all combinations
-    keys = param_grid.keys()
-    values = param_grid.values()
-    param_combinations = [dict(zip(keys, combination)) for combination in itertools.product(*values)]
-    
-    # Split data
-    test_size = int(len(series_df) * test_fraction)
-    train_df = series_df.iloc[:-test_size].copy()
-    test_df = series_df.iloc[-test_size:].copy()
-    
-    best_nrmse = float('inf')
-    best_params = {}
-    
-    # Suppress Prophet output
-    import logging
-    logging.getLogger('prophet').setLevel(logging.ERROR)
-    
-    # Try each parameter combination (limit to avoid timeout)
-    max_combinations = 20  # Limit for performance
-    param_combinations = param_combinations[:max_combinations]
-    
-    for params in param_combinations:
-        try:
-            # Train model with current parameters
-            model = Prophet(**params)
-            model.fit(train_df)
-            
-            # Make predictions
-            future = model.make_future_dataframe(periods=test_size)
-            forecast = model.predict(future)
-            
-            # Calculate NRMSE
-            yhat_test = forecast['yhat'].iloc[-test_size:].to_numpy()
-            y_true = test_df['y'].to_numpy()
-            rmse = float(np.sqrt(np.mean((y_true - yhat_test) ** 2)))
-            y_range = np.max(y_true) - np.min(y_true)
-            nrmse = rmse / y_range if y_range > 0 else rmse
-            
-            if nrmse < best_nrmse:
-                best_nrmse = nrmse
-                best_params = params.copy()
-                
-        except Exception:
-            # Skip problematic parameter combinations
-            continue
-    
-    # Return default parameters if optimization failed
-    if not best_params:
-        best_params = {
-            'daily_seasonality': True,
-            'weekly_seasonality': True,
-            'yearly_seasonality': True,
-            'changepoint_prior_scale': 0.05,
-            'seasonality_prior_scale': 10.0
-        }
-    
-    return best_params
-
-
-
-
-
-def _compute_prophet_forecast_and_nrmse(series_df: pd.DataFrame, test_fraction: float = 0.2, optimize_params: bool = True) -> Tuple[float, pd.DataFrame, pd.DataFrame]:
-    """
-    Compute Prophet forecast and NRMSE on test set.
-    
-    Args:
-        series_df: DataFrame with 'ds' and 'y' columns
-        test_fraction: Fraction of data to use for testing
-        optimize_params: Whether to optimize parameters for this dataset
-        
-    Returns:
-        tuple: (nrmse, forecast_df, test_df)
-    """
-    # Split data
-    test_size = int(len(series_df) * test_fraction)
-    train_df = series_df.iloc[:-test_size].copy()
-    test_df = series_df.iloc[-test_size:].copy()
-    
-    # Get optimal parameters if requested
-    if optimize_params:
-        prophet_params = _optimize_prophet_parameters(series_df, test_fraction)
-    else:
-        prophet_params = {
-            'daily_seasonality': True,
-            'weekly_seasonality': True,
-            'yearly_seasonality': True,
-            'changepoint_prior_scale': 0.05,
-            'seasonality_prior_scale': 10.0
-        }
-    
-    # Train Prophet model with optimal parameters
-    model = Prophet(**prophet_params)
-    
-    # Suppress Prophet output
-    import logging
-    logging.getLogger('prophet').setLevel(logging.WARNING)
-    
-    model.fit(train_df)
-    
-    # Create future dataframe for forecasting
-    future = model.make_future_dataframe(periods=test_size)
-    forecast = model.predict(future)
-    
-    # Calculate NRMSE on test set
-    yhat_test = forecast['yhat'].iloc[-test_size:].to_numpy()
-    y_true = test_df['y'].to_numpy()
-    rmse = float(np.sqrt(np.mean((y_true - yhat_test) ** 2)))
-    # Normalize by range of true values
-    y_range = np.max(y_true) - np.min(y_true)
-    nrmse = rmse / y_range if y_range > 0 else rmse
-    
-    return nrmse, forecast, test_df
-
-
 @st.cache_data(show_spinner=False)
 def _compute_benchmark(dataset_names: Tuple[str, ...], optimize_parameters: bool = True) -> pd.DataFrame:
     """Compute benchmark results for all datasets."""
@@ -304,7 +168,7 @@ def _compute_benchmark(dataset_names: Tuple[str, ...], optimize_parameters: bool
             series_df = _prepare_single_series(raw_df)
             
             # Compute Prophet NRMSE
-            prophet_nrmse, _, _ = _compute_prophet_forecast_and_nrmse(series_df, test_fraction=0.2, optimize_params=optimize_parameters)
+            prophet_nrmse, _, _ = prophet_forecast_and_nrmse(series_df, test_fraction=0.2, optimize_params_flag=optimize_parameters)
             
             results.append({
                 "Dataset": name,
@@ -359,7 +223,7 @@ with col2:
         with st.spinner(f"Generating forecast..."):
             raw_df, metadata = _load_dataset(selected)
             series_df = _prepare_single_series(raw_df)
-            nrmse, forecast, test_df = _compute_prophet_forecast_and_nrmse(series_df, test_fraction=0.2, optimize_params=optimize_params)
+            nrmse, forecast, test_df = prophet_forecast_and_nrmse(series_df, test_fraction=0.2, optimize_params_flag=optimize_params)
 
         # Compact info display
         st.caption(f"**{selected}** | NRMSE: {nrmse:.4f} | Points: {len(series_df)} | Test: {len(test_df)}")


### PR DESCRIPTION
Move Prophet model training and forecasting logic to a dedicated `models/prophet_model.py` file.

This refactoring separates model-specific code from the main Streamlit application, allowing for easier integration and management of multiple forecasting models in the future without modifying the core app logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef62f388-fe7b-4e33-bd28-096eb71a324a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef62f388-fe7b-4e33-bd28-096eb71a324a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

