### PR TITLE
Limit training data to 1000 rows

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -143,7 +143,7 @@ def _load_dataset(name: str) -> Tuple[pd.DataFrame, dict]:
 def _prepare_single_series(df: pd.DataFrame) -> pd.DataFrame:
 	"""Prepare dataset for forecasting."""
 	# Already in correct format (ds, y)
-	sub = df[["ds", "y"]].copy()
+	sub = df[[("ds"), ("y")]].copy()
 	
 	# Ensure proper types
 	sub["ds"] = pd.to_datetime(sub["ds"])
@@ -152,6 +152,10 @@ def _prepare_single_series(df: pd.DataFrame) -> pd.DataFrame:
 	
 	# Deduplicate by timestamp (shouldn't be needed for generated data)
 	sub = sub.groupby("ds", as_index=False).agg({"y": "mean"})
+	
+	# Limit to last 1000 rows for training/evaluation
+	if len(sub) > 1000:
+		sub = sub.iloc[-1000:].reset_index(drop=True)
 	
 	return sub
 


### PR DESCRIPTION
Limit training data to 1000 rows to align with user requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba213d18-bb55-410e-ad5b-6bd16bc3305d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba213d18-bb55-410e-ad5b-6bd16bc3305d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

